### PR TITLE
Fix CA1416 warnings false positive

### DIFF
--- a/Platforms/Android/MainActivity.cs
+++ b/Platforms/Android/MainActivity.cs
@@ -19,7 +19,7 @@ public class MainActivity : MauiAppCompatActivity
     {
 
 
-        if (Build.VERSION.SdkInt < BuildVersionCodes.O)
+        if (!OperatingSystem.IsAndroidVersionAtLeast(26))
         {
             // Notification channels are new in API 26 (and not a part of the
             // support library). There is no need to create a notification 

--- a/Platforms/Android/MyFirebaseMessaging.cs
+++ b/Platforms/Android/MyFirebaseMessaging.cs
@@ -53,7 +53,7 @@ namespace MAUI_Notification.Platforms.Android
 
             NotificationCompat.Builder notificationBuilder;
             PendingIntent pendingIntent = null;
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.S)
+            if (OperatingSystem.IsAndroidVersionAtLeast(31))
             {
                 pendingIntent = PendingIntent.GetActivity(this, 100, intent, PendingIntentFlags.Mutable);
             }


### PR DESCRIPTION
Current API version verification is not recognized by analyzers.
Use `OperatingSystem.IsAndroidVersionAtLeast` to prevent CA1416 false positive.

https://learn.microsoft.com/dotnet/maui/migration/android-projects?view=net-maui-8.0#changes-to-androidmanifestxml
